### PR TITLE
#24203 adding multiple fields to same model should attempt to run single ALTER TABLE statement

### DIFF
--- a/django/db/migrations/operations/__init__.py
+++ b/django/db/migrations/operations/__init__.py
@@ -1,13 +1,13 @@
 from .models import (CreateModel, DeleteModel, AlterModelTable,
     AlterUniqueTogether, AlterIndexTogether, RenameModel, AlterModelOptions,
     AlterOrderWithRespectTo, AlterModelManagers)
-from .fields import AddField, RemoveField, AlterField, RenameField
+from .fields import AddField, RemoveField, AlterField, RenameField, AddFieldList
 from .special import SeparateDatabaseAndState, RunSQL, RunPython
 
 __all__ = [
     'CreateModel', 'DeleteModel', 'AlterModelTable', 'AlterUniqueTogether',
     'RenameModel', 'AlterIndexTogether', 'AlterModelOptions',
-    'AddField', 'RemoveField', 'AlterField', 'RenameField',
+    'AddField', 'RemoveField', 'AlterField', 'RenameField', 'AddFieldList',
     'SeparateDatabaseAndState', 'RunSQL', 'RunPython',
     'AlterOrderWithRespectTo', 'AlterModelManagers',
 ]

--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -78,6 +78,10 @@ class AddField(Operation):
         return self.references_model(model_name) and name.lower() == self.name_lower
 
 
+class AddFieldList(Operation):
+    pass
+
+
 class RemoveField(Operation):
     """
     Removes a field from a model.

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -423,3 +423,18 @@ class OptimizerTests(TestCase):
                 migrations.CreateModel("Bar", [("width", models.IntegerField())]),
             ],
         )
+
+    def test_add_field_optimization(self):
+        """
+        Adding multiple field to same models should generate one AddFieldList operation
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.AddField("Foo", "field1", models.IntegerField),
+                migrations.AddField("Foo", "field2", models.IntegerField),
+             ],
+            [
+                migrations.AddFieldList("Foo", [("field1", models.IntegerField),
+                                                ("field2", models.IntegerField)])
+            ],
+        )


### PR DESCRIPTION
Initial ideas to optimise migration process.

Origin: https://code.djangoproject.com/ticket/24203
